### PR TITLE
Option to enable/disable reformatting of HTML mail templates

### DIFF
--- a/api/src/services/mail/index.ts
+++ b/api/src/services/mail/index.ts
@@ -23,6 +23,7 @@ export type EmailOptions = SendMailOptions & {
 		name: string;
 		data: Record<string, any>;
 	};
+	reformatHtml?: boolean;
 };
 
 export class MailService {

--- a/api/src/services/mail/index.ts
+++ b/api/src/services/mail/index.ts
@@ -64,7 +64,7 @@ export class MailService {
 			html = await this.renderTemplate(template.name, templateData);
 		}
 
-		if (typeof html === 'string') {
+		if (typeof html === 'string' && (options.reformatHtml === undefined || options.reformatHtml === true)) {
 			// Some email clients start acting funky when line length exceeds 75 characters. See #6074
 			html = prettier.format(html as string, { parser: 'html', printWidth: 70, tabWidth: 0 });
 		}


### PR DESCRIPTION
With reformatHtml we can enable or disable reformatting of HTML templates; If not specified, reformatting will be executed (downward compatability).